### PR TITLE
Prefer `head` when rendering responses with no content

### DIFF
--- a/lib/two_factor_authentication/controllers/helpers.rb
+++ b/lib/two_factor_authentication/controllers/helpers.rb
@@ -24,7 +24,7 @@ module TwoFactorAuthentication
           session["#{scope}_return_to"] = request.original_fullpath if request.get?
           redirect_to two_factor_authentication_path_for(scope)
         else
-          render nothing: true, status: :unauthorized
+          head :unauthorized
         end
       end
 


### PR DESCRIPTION
The `nothing` option has been removed as of rails 5.1
https://github.com/rails/rails/commit/57e1c99a280bdc1b324936a690350320a1cd8111

I tried to write a spec for this, but since it's only broken as of rails 5.1 it would require me to update the Gemfile as well as the example/test app in the specs. So I decided to just test this manually within the portal instead, which proved this fix worked.